### PR TITLE
feat: add lib5 library for adding numbers

### DIFF
--- a/libs/lib5/.babelrc
+++ b/libs/lib5/.babelrc
@@ -1,0 +1,11 @@
+{
+  "presets": [
+    [
+      "@nx/js/babel",
+      {
+        "useBuiltIns": "usage",
+        "corejs": 3
+      }
+    ]
+  ]
+}

--- a/libs/lib5/README.md
+++ b/libs/lib5/README.md
@@ -1,0 +1,16 @@
+# lib5
+
+A simple library for adding two numbers together.
+
+## Usage
+
+```typescript
+import { addNumbers } from '@react-demo/lib5';
+
+const result = addNumbers(2, 3);
+console.log(result); // 5
+```
+
+## Running unit tests
+
+Run `nx test lib5` to execute the unit tests via [Vitest](https://vitest.dev/).

--- a/libs/lib5/eslint.config.mjs
+++ b/libs/lib5/eslint.config.mjs
@@ -1,0 +1,20 @@
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    // Override or add rules here
+    rules: {},
+  },
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    // Override or add rules here
+    rules: {},
+  },
+  {
+    files: ['**/*.js', '**/*.jsx'],
+    // Override or add rules here
+    rules: {},
+  },
+];

--- a/libs/lib5/package.json
+++ b/libs/lib5/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@react-demo/lib5",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "nx": {
+    "name": "lib5"
+  }
+}

--- a/libs/lib5/src/index.ts
+++ b/libs/lib5/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/lib5';

--- a/libs/lib5/src/lib/lib5.spec.ts
+++ b/libs/lib5/src/lib/lib5.spec.ts
@@ -1,0 +1,45 @@
+import { addNumbers, addMultipleNumbers } from './lib5';
+
+describe('lib5', () => {
+  describe('addNumbers', () => {
+    it('should add two positive numbers correctly', () => {
+      expect(addNumbers(2, 3)).toBe(5);
+    });
+
+    it('should add negative numbers correctly', () => {
+      expect(addNumbers(-2, -3)).toBe(-5);
+    });
+
+    it('should add positive and negative numbers correctly', () => {
+      expect(addNumbers(5, -3)).toBe(2);
+    });
+
+    it('should handle zero', () => {
+      expect(addNumbers(0, 5)).toBe(5);
+      expect(addNumbers(5, 0)).toBe(5);
+      expect(addNumbers(0, 0)).toBe(0);
+    });
+
+    it('should handle decimals', () => {
+      expect(addNumbers(1.5, 2.3)).toBeCloseTo(3.8);
+    });
+  });
+
+  describe('addMultipleNumbers', () => {
+    it('should add multiple numbers correctly', () => {
+      expect(addMultipleNumbers([1, 2, 3, 4])).toBe(10);
+    });
+
+    it('should handle empty array', () => {
+      expect(addMultipleNumbers([])).toBe(0);
+    });
+
+    it('should handle single number', () => {
+      expect(addMultipleNumbers([5])).toBe(5);
+    });
+
+    it('should handle negative numbers', () => {
+      expect(addMultipleNumbers([1, -2, 3, -4])).toBe(-2);
+    });
+  });
+});

--- a/libs/lib5/src/lib/lib5.ts
+++ b/libs/lib5/src/lib/lib5.ts
@@ -1,0 +1,18 @@
+/**
+ * Adds two numbers together
+ * @param a - The first number
+ * @param b - The second number
+ * @returns The sum of a and b
+ */
+export function addNumbers(a: number, b: number): number {
+  return a + b;
+}
+
+/**
+ * Adds an array of numbers together
+ * @param numbers - Array of numbers to sum
+ * @returns The sum of all numbers
+ */
+export function addMultipleNumbers(numbers: number[]): number {
+  return numbers.reduce((sum, num) => sum + num, 0);
+}

--- a/libs/lib5/tsconfig.json
+++ b/libs/lib5/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false,
+    "emitDeclarationOnly": false,
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/lib5/tsconfig.lib.json
+++ b/libs/lib5/tsconfig.lib.json
@@ -1,0 +1,24 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "outDir": "../../dist/libs/lib5",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "exclude": [
+    "eslint.config.mjs",
+    "vitest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.js",
+    "src/**/*.test.js",
+    "src/**/*.spec.jsx",
+    "src/**/*.test.jsx"
+  ],
+  "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
+}

--- a/libs/lib5/tsconfig.spec.json
+++ b/libs/lib5/tsconfig.spec.json
@@ -1,0 +1,24 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "emitDeclarationOnly": false,
+    "noEmit": true,
+    "outDir": "../../dist/out-tsc",
+    "module": "esnext",
+    "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
+  },
+  "include": [
+    "vite.config.ts",
+    "vitest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/libs/lib5/vite.config.ts
+++ b/libs/lib5/vite.config.ts
@@ -1,0 +1,53 @@
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
+import * as path from 'path';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+
+export default defineConfig({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/libs/lib5',
+  plugins: [
+    nxViteTsPaths(),
+    nxCopyAssetsPlugin(['*.md']),
+    dts({
+      entryRoot: 'src',
+      tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
+    }),
+  ],
+  // Uncomment this if you are using workers.
+  // worker: {
+  //  plugins: [ nxViteTsPaths() ],
+  // },
+  // Configuration for building your library.
+  // See: https://vitejs.dev/guide/build.html#library-mode
+  build: {
+    outDir: '../../dist/libs/lib5',
+    emptyOutDir: true,
+    reportCompressedSize: true,
+    commonjsOptions: {
+      transformMixedEsModules: true,
+    },
+    lib: {
+      entry: 'src/index.ts',
+      name: 'lib5',
+      fileName: 'index',
+      formats: ['es', 'cjs'],
+    },
+    rollupOptions: {
+      external: [],
+    },
+  },
+  test: {
+    watch: false,
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: '../../coverage/libs/lib5',
+      provider: 'v8',
+    },
+  },
+});


### PR DESCRIPTION
This PR implements the feature request from issue #4 by creating a new library called `lib5` that provides functionality to add numbers together.

## What's included:

- **Main functionality**: `addNumbers(a, b)` function that adds two numbers
- **Bonus functionality**: `addMultipleNumbers(numbers[])` function that adds an array of numbers
- **Comprehensive tests**: Unit tests covering positive/negative numbers, decimals, edge cases
- **TypeScript support**: Full type definitions and exports
- **Nx configuration**: Proper build, test, and lint configurations
- **Documentation**: README with usage examples

## Usage:

```typescript
import { addNumbers, addMultipleNumbers } from '@react-demo/lib5';

// Add two numbers
const result = addNumbers(2, 3); // returns 5

// Add multiple numbers
const total = addMultipleNumbers([1, 2, 3, 4]); // returns 10
```

## Tests:
The library includes comprehensive test coverage for various scenarios including edge cases with negative numbers, decimals, and empty arrays.

Fixes #4